### PR TITLE
Switch to ppw-singer-python to have custom loggings

### DIFF
--- a/sample_logging.conf
+++ b/sample_logging.conf
@@ -1,0 +1,25 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stderr
+
+[formatters]
+keys=child
+
+[logger_root]
+level=INFO
+handlers=stderr
+formatter=child
+propagate=0
+
+[handler_stderr]
+level=INFO
+class=StreamHandler
+formatter=child
+args=(sys.stderr,)
+
+[formatter_child]
+class=logging.Formatter
+format=time=%(asctime)s name=%(name)s level=%(levelname)s message=%(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pipelinewise-tap-zuora',
       ],
       py_modules=['tap_zuora'],
       install_requires=[
-          'singer-python==5.1.1',
+          'pipelinewise-singer-python==1.*',
           'requests==2.20.0',
           'pendulum==1.2.0',
       ],


### PR DESCRIPTION
Switch `singer-python` dependency to `pipelinewise-singer-python`.

PPW singer python comes with an option to use custom logging conf that is used in the upstream pipelinewise and every PPW compatible connector.